### PR TITLE
fix import of version string in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup
-from rdf2puml import __version__
+from generators import __version__
 
 setup(name='generators',
       version=__version__,


### PR DESCRIPTION
Probably fixing a copy-paste leftover here. Fixes installation for me and bp2023ap1. No idea how this could have ever worked. :)